### PR TITLE
Added sales storage by id and month

### DIFF
--- a/CSVInput/Jon_Test.csv
+++ b/CSVInput/Jon_Test.csv
@@ -1,0 +1,4 @@
+Name,ID,Category,Sub-Category,Location,Quantity,Backorder,Sale Price,Tax,Total Price,Buy Cost,Profit,Expiration Date
+ Apple,1,Perishable,None,2,100,0,3.99,0.1,4.389,1,2.99,12/12/2022
+ Orange,2,Perishable,None,2,100,0,3.99,0.1,4.389,1,2.99,12/12/2022
+ Pomegranate,3,Perishable,None,2,100,0,3.99,0.1,4.389,1,2.99,12/12/2022

--- a/include/Sales.hpp
+++ b/include/Sales.hpp
@@ -32,6 +32,7 @@ class Sale {
    private:
     friend class Transaction;
     friend class SaleList;
+    friend class SalesComparison;
 
    protected:
     unsigned long sale_id, item_id, num_sold;

--- a/include/SalesComparison.hpp
+++ b/include/SalesComparison.hpp
@@ -41,8 +41,8 @@ class SalesComparison {
     /*
      * @brief The compareLast functions will compare sales from your current year, month, or day with data from the
      * past 10 years, 5 years, month, 7days, or just yesterday.
-     * @param int number of years to compare
-     * @return %difference of current / past.
+     * @param int - number of years to compare
+     * @return %difference of current / past
      */
     double compareLastXYears(int);
     double compareLastMonth();
@@ -53,10 +53,12 @@ class SalesComparison {
     std::map<int, double> salesByYear;   // This will store all past sales totals based on the year.
     double avgByYear;                    // This will store the average of all past sales totals based on the year.
     std::map<int, double> salesByMonth;  // This will store all past sales totals based on the month of the year.
+    std::map<int, std::map<unsigned long, double> > itemIdsByMonth; //This stores item totals averaged by month.
+    std::map<unsigned long, double> currentMonthItemIds; //This stores this month's total items by id.
     std::map<int, double> avgByMonth;    // This will store the average of all past sales totals based on the month.
-    double currentYearSales;             // This will store the running sales total of the current year.
-    double currentMonthSales;            // This will store the running sales total of the current month.
-    double currentDaySales;              // This will store the running sales total of the day.
+    double currentYearSales = 0;             // This will store the running sales total of the current year.
+    double currentMonthSales = 0;            // This will store the running sales total of the current month.
+    double currentDaySales = 0;              // This will store the running sales total of the day.
     unsigned int curr_y, curr_m, curr_d;
     double daysLeftYear;
     double daysLeftMonth;

--- a/src/InventoryManager.cpp
+++ b/src/InventoryManager.cpp
@@ -26,8 +26,8 @@ int InventoryManager::userInput() {
         return -1;
     }
 
-    std::cout << "\n(A)dd, (R)emove, (U)pdate, (S)ale, (C)hange Permissions, (CS)Compare Sales, (P)rint, (L)ogout, or "
-                 "(Q)uit: ";
+    std::cout << "\n(A)dd, (R)emove, (U)pdate, (S)ale, (C)hange Permissions, (CS)Compare Sales, "
+                 "(P)rint, (L)ogout, or (Q)uit: ";
     std::cin >> argument;
     lowerCaseString(argument);
 
@@ -185,7 +185,7 @@ int InventoryManager::userInput() {
             active_inventory->printItems("", category);
         }
         Logger::logTrace("User %s viewed the inventory.", current_user->name.c_str());
-    } else if (argument == "s" || argument == "sales") {
+    }  else if (argument == "s" || argument == "sales") {
         std::cin.clear();
         std::cin.ignore(10000, '\n');
 
@@ -212,14 +212,14 @@ int InventoryManager::userInput() {
 
             if (item_ptr != NULL) {
                 sale_list->transaction_by_order[sale_list->curr_transaction]->addSale(
-                    sale_list->curr_sale_id, item_ptr->id, stoul(quantity), item_ptr->sale_price);
+                        sale_list->curr_sale_id, item_ptr->id, stoul(quantity), item_ptr->sale_price);
                 valid_transaction = true;
             } else
                 Logger::logWarn("Invalid item -- continuing to read.");
         }
 
         /* if no valid sales are added to the transaction, then it is deleted, once proper delete feture is added
-         * this will be changed */
+        * this will be changed */
         if (valid_transaction == false) {
             Logger::logError("Invalid transaction -- no valid sales were input.  Continuing to read.");
             sale_list->transaction_by_order.pop_back();

--- a/src/SalesComparison.cpp
+++ b/src/SalesComparison.cpp
@@ -199,15 +199,15 @@ void SalesComparison::printComparison(std::string function, int x) {
     if (function == "ByYear") {
         result = compareByYear();
         fprintf(stdout,
-                "Average sales per year : %.2f\n"
-                "Sales so far this year : %.2f\n"
+                "Average sales per year : $%.2f\n"
+                "Sales so far this year : $%.2f\n"
                 "Gain this year vs avg  : %%%.2f\n\n",
                 avgByYear, currentYearSales, result);
     } else if (function == "ByMonth") {
         result = compareByMonth();
         fprintf(stdout,
-                "Average sales per month %d : %.2f\n"
-                "Sales so far this month    : %.2f\n"
+                "Average sales per month %d : $%.2f\n"
+                "Sales so far this month    : $%.2f\n"
                 "Gain this month vs avg     : %%%.2f\n\n",
                 curr_m, avgByMonth[curr_m] * (1 - daysLeftMonth), currentMonthSales, result);
     } else if (function == "LastXYears") {
@@ -242,15 +242,15 @@ void SalesComparison::printAllComparisons() {
 
     result = compareByYear();
     fprintf(stdout,
-            "Average sales per year : %.2f\n"
-            "Sales so far this year : %.2f\n"
+            "Average sales per year : $%.2f\n"
+            "Sales so far this year : $%.2f\n"
             "Gain this year vs avg  : %%%.2f\n\n",
             avgByYear, currentYearSales, result - 100);
 
     result = compareByMonth();
     fprintf(stdout,
-            "Average sales per month %d : %.2f\n"
-            "Sales so far this month    : %.2f\n"
+            "Average sales per month %d : $%.2f\n"
+            "Sales so far this month    : $%.2f\n"
             "Gain this month vs avg     : %%%.2f\n\n",
             curr_m, avgByMonth[curr_m] * (1 - daysLeftMonth), currentMonthSales, result - 100);
 

--- a/src/SalesComparison.cpp
+++ b/src/SalesComparison.cpp
@@ -43,7 +43,7 @@ void SalesComparison::setup(std::shared_ptr<SaleList> sale_list) {
                             currentMonthSales += yit->second[i]->total_price;
                             for (long unsigned int j = 0; j < yit->second[i]->sales.size(); j++) {
                                 currentMonthItemIds[yit->second[i]->sales[j]->item_id] +=
-                                        yit->second[i]->sales[j]->sale_price * yit->second[i]->sales[j]->num_sold;
+                                    yit->second[i]->sales[j]->sale_price * yit->second[i]->sales[j]->num_sold;
                             }
                         }
                         if (dit->first == curr_d) {
@@ -57,9 +57,8 @@ void SalesComparison::setup(std::shared_ptr<SaleList> sale_list) {
                         salesByYear[yit->second[i]->year] += yit->second[i]->total_price;
                         salesByMonth[yit->second[i]->month] += yit->second[i]->total_price;
                         for (long unsigned int j = 0; j < yit->second[i]->sales.size(); j++) {
-                            //std::cout << itemIdsByMonth[yit->second[i]->month][yit->second[i]->sales[j]->item_id] << std::endl;
                             itemIdsByMonth[yit->second[i]->month][yit->second[i]->sales[j]->item_id] +=
-                                    yit->second[i]->sales[j]->sale_price * yit->second[i]->sales[j]->num_sold;
+                                yit->second[i]->sales[j]->sale_price * yit->second[i]->sales[j]->num_sold;
                         }
                     }
                 }
@@ -81,9 +80,7 @@ void SalesComparison::setup(std::shared_ptr<SaleList> sale_list) {
 
     for (it = itemIdsByMonth.begin(); it != itemIdsByMonth.end(); it++) {
         for (idIt = it->second.begin(); idIt != it->second.end(); idIt++) {
-            //printf("idIt->second : %f\nnumYears : %f\n", idIt->second, numYears);
             idIt->second /= numYears;
-            //printf("new idIt->second : %f\n", idIt->second);
         }
     }
 
@@ -476,4 +473,3 @@ double SalesComparison::compareYesterday() {
         return 0;
     }
 }
-


### PR DESCRIPTION
This fixes SalesComparisons to account for the new date format. 
It also stores how much of an item is sold based on the item id and the month. 
Every item sold is stored by it's month and then that number is averaged over the number of years the store has sold items.